### PR TITLE
fix _clone of sqs filter

### DIFF
--- a/haystack/query.py
+++ b/haystack/query.py
@@ -626,6 +626,8 @@ class SearchQuerySet(object):
         query = self.query._clone()
         clone = klass(query=query)
         clone._load_all = self._load_all
+        clone._using = self._using
+
         return clone
 
 


### PR DESCRIPTION
Fixing haystack queries losing `using` info while querying