### PR TITLE
Set the default value of --using option of update_index to "default" …

### DIFF
--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -163,7 +163,7 @@ class Command(BaseCommand):
             help='Remove objects from the index that are no longer present in the database.'
         )
         parser.add_argument(
-            '-u', '--using', action='append', default=[],
+            '-u', '--using', action='append', default=['default'],
             help='Update only the named backend (can be used multiple times). '
                  'By default all backends will be updated.'
         )


### PR DESCRIPTION
Because new comtrade search_index instance is optimized for the size of new-comtrade db. It will be critical if someone makes a mistake of not specifying the --using option while updating the index. Therefore, set the default value of it to "default"