### PR TITLE
[refactor/django] Replace deprecated django module usage

### DIFF
--- a/haystack/admin.py
+++ b/haystack/admin.py
@@ -7,7 +7,7 @@ from django.contrib.admin.views.main import SEARCH_VAR, ChangeList
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import InvalidPage, Paginator
 from django.shortcuts import render
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.translation import ungettext
 
 from haystack import connections
@@ -128,7 +128,7 @@ class SearchModelAdminMixin(object):
             'All %(total_count)s selected', changelist.result_count)
 
         context = {
-            'module_name': force_text(self.model._meta.verbose_name_plural),
+            'module_name': force_str(self.model._meta.verbose_name_plural),
             'selection_note': selection_note % {'count': len(changelist.result_list)},
             'selection_note_all': selection_note_all % {'total_count': changelist.result_count},
             'title': changelist.title,

--- a/haystack/backends/__init__.py
+++ b/haystack/backends/__init__.py
@@ -6,9 +6,9 @@ from time import time
 from django.conf import settings
 from django.db.models import Q
 from django.db.models.base import ModelBase
-from django.utils import six
+import six
 from django.utils import tree
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from haystack.constants import VALID_FILTERS, FILTER_SEPARATOR, DEFAULT_ALIAS
 from haystack.exceptions import MoreLikeThisError, FacetingError
@@ -141,7 +141,7 @@ class BaseSearchBackend(object):
         Hook to give the backend a chance to prep an attribute value before
         sending it to the search engine. By default, just force it to unicode.
         """
-        return force_text(value)
+        return force_str(value)
 
     def more_like_this(self, model_instance, additional_query_string=None, result_class=None):
         """
@@ -359,9 +359,9 @@ class SearchNode(tree.Node):
 
     def _repr_query_fragment_callback(self, field, filter_type, value):
         if six.PY3:
-            value = force_text(value)
+            value = force_str(value)
         else:
-            value = force_text(value).encode('utf8')
+            value = force_str(value).encode('utf8')
 
         return "%s%s%s=%s" % (field, FILTER_SEPARATOR, filter_type, value)
 

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+import six
 
 import haystack
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query

--- a/haystack/backends/simple_backend.py
+++ b/haystack/backends/simple_backend.py
@@ -9,7 +9,7 @@ from warnings import warn
 
 from django.conf import settings
 from django.db.models import Q
-from django.utils import six
+import six
 
 from haystack import connections
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query, SearchNode

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -6,7 +6,7 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+import six
 
 import haystack
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, EmptyResults, log_query

--- a/haystack/backends/whoosh_backend.py
+++ b/haystack/backends/whoosh_backend.py
@@ -11,9 +11,9 @@ import warnings
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+import six
 from django.utils.datetime_safe import datetime
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, EmptyResults, log_query
 from haystack.constants import DJANGO_CT, DJANGO_ID, ID
@@ -314,7 +314,7 @@ class WhooshSearchBackend(BaseSearchBackend):
                 'hits': 0,
             }
 
-        query_string = force_text(query_string)
+        query_string = force_str(query_string)
 
         # A one-character query (non-wildcard) gets nabbed by a stopwords
         # filter and should yield zero results.
@@ -392,7 +392,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             narrow_searcher = self.index.searcher()
 
             for nq in narrow_queries:
-                recent_narrowed_results = narrow_searcher.search(self.parser.parse(force_text(nq)),
+                recent_narrowed_results = narrow_searcher.search(self.parser.parse(force_str(nq)),
                                                                  limit=None)
 
                 if len(recent_narrowed_results) <= 0:
@@ -517,7 +517,7 @@ class WhooshSearchBackend(BaseSearchBackend):
             narrow_searcher = self.index.searcher()
 
             for nq in narrow_queries:
-                recent_narrowed_results = narrow_searcher.search(self.parser.parse(force_text(nq)),
+                recent_narrowed_results = narrow_searcher.search(self.parser.parse(force_str(nq)),
                                                                  limit=None)
 
                 if len(recent_narrowed_results) <= 0:
@@ -661,7 +661,7 @@ class WhooshSearchBackend(BaseSearchBackend):
         spelling_suggestion = None
         reader = self.index.reader()
         corrector = reader.corrector(self.content_field_name)
-        cleaned_query = force_text(query_string)
+        cleaned_query = force_str(query_string)
 
         if not query_string:
             return spelling_suggestion
@@ -701,12 +701,12 @@ class WhooshSearchBackend(BaseSearchBackend):
             else:
                 value = 'false'
         elif isinstance(value, (list, tuple)):
-            value = u','.join([force_text(v) for v in value])
+            value = u','.join([force_str(v) for v in value])
         elif isinstance(value, (six.integer_types, float)):
             # Leave it alone.
             pass
         else:
-            value = force_text(value)
+            value = force_str(value)
         return value
 
     def _to_python(self, value):
@@ -749,9 +749,9 @@ class WhooshSearchBackend(BaseSearchBackend):
 class WhooshSearchQuery(BaseSearchQuery):
     def _convert_datetime(self, date):
         if hasattr(date, 'hour'):
-            return force_text(date.strftime('%Y%m%d%H%M%S'))
+            return force_str(date.strftime('%Y%m%d%H%M%S'))
         else:
-            return force_text(date.strftime('%Y%m%d000000'))
+            return force_str(date.strftime('%Y%m%d000000'))
 
     def clean(self, query_fragment):
         """

--- a/haystack/fields.py
+++ b/haystack/fields.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 
 from django.template import loader
-from django.utils import datetime_safe, six
+from django.utils import datetime_safe
+import six
 
 from haystack.exceptions import SearchFieldError
 from haystack.utils import get_model_ct_tuple

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -7,8 +7,8 @@ import threading
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import force_text
-from django.utils.six import with_metaclass
+from django.utils.encoding import force_str
+from six import with_metaclass
 
 from haystack import connection_router, connections
 from haystack.constants import DEFAULT_ALIAS, DJANGO_CT, DJANGO_ID, ID, Indexable
@@ -190,7 +190,7 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         self.prepared_data = {
             ID: get_identifier(obj),
             DJANGO_CT: get_model_ct(obj),
-            DJANGO_ID: force_text(obj.pk),
+            DJANGO_ID: force_str(obj.pk),
         }
 
         for field_name, field in self.fields.items():

--- a/haystack/inputs.py
+++ b/haystack/inputs.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import re
 import warnings
 
-from django.utils.encoding import force_text, python_2_unicode_compatible
+from six import python_2_unicode_compatible
+from django.utils.encoding import force_str
 
 
 @python_2_unicode_compatible
@@ -24,7 +25,7 @@ class BaseInput(object):
         return u"<%s '%s'>" % (self.__class__.__name__, self)
 
     def __str__(self):
-        return force_text(self.query_string)
+        return force_str(self.query_string)
 
     def prepare(self, query_obj):
         return self.query_string

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.core.management.base import BaseCommand
-from django.utils import six
+import six
 
 from haystack import connections
 

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 
 from django.core.management.base import BaseCommand
 from django.db import close_old_connections, reset_queries
-from django.utils.encoding import force_text, smart_bytes
+from django.utils.encoding import force_str, smart_bytes
 from django.utils.timezone import now
 
 from haystack import connections as haystack_connections
@@ -257,7 +257,7 @@ class Command(BaseCommand):
 
             if self.verbosity >= 1:
                 self.stdout.write(u"Indexing %d %s" % (
-                    total, force_text(model._meta.verbose_name_plural))
+                    total, force_str(model._meta.verbose_name_plural))
                 )
 
             batch_size = self.batchsize or backend.batch_size

--- a/haystack/models.py
+++ b/haystack/models.py
@@ -5,8 +5,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import six
-from django.utils.encoding import force_text
+import six
+from django.utils.encoding import force_str
 from django.utils.text import capfirst
 
 from haystack.exceptions import NotHandled, SpatialError
@@ -55,7 +55,7 @@ class SearchResult(object):
         return "<SearchResult: %s.%s (pk=%r)>" % (self.app_label, self.model_name, self.pk)
 
     def __unicode__(self):
-        return force_text(self.__repr__())
+        return force_str(self.__repr__())
 
     def __getattr__(self, attr):
         if attr == '__getnewargs__':
@@ -150,7 +150,7 @@ class SearchResult(object):
             self.log.error("Model could not be found for SearchResult '%s'.", self)
             return u''
 
-        return force_text(capfirst(self.model._meta.verbose_name))
+        return force_str(capfirst(self.model._meta.verbose_name))
 
     verbose_name = property(_get_verbose_name)
 
@@ -159,7 +159,7 @@ class SearchResult(object):
             self.log.error("Model could not be found for SearchResult '%s'.", self)
             return u''
 
-        return force_text(capfirst(self.model._meta.verbose_name_plural))
+        return force_str(capfirst(self.model._meta.verbose_name_plural))
 
     verbose_name_plural = property(_get_verbose_name_plural)
 

--- a/haystack/panels.py
+++ b/haystack/panels.py
@@ -6,7 +6,7 @@ import datetime
 
 from debug_toolbar.panels import DebugPanel
 from django.template.loader import render_to_string
-from django.utils import six
+import six
 from django.utils.translation import ugettext_lazy as _
 
 from haystack import connections

--- a/haystack/query.py
+++ b/haystack/query.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import operator
 import warnings
 
-from django.utils import six
+import six
 
 from haystack import connection_router, connections
 from haystack.backends import SQ

--- a/haystack/templatetags/highlight.py
+++ b/haystack/templatetags/highlight.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django import template
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+import six
 
 from haystack.utils import importlib
 

--- a/haystack/utils/__init__.py
+++ b/haystack/utils/__init__.py
@@ -6,7 +6,7 @@ import importlib
 import re
 
 from django.conf import settings
-from django.utils import six
+import six
 
 from haystack.constants import ID, DJANGO_CT, DJANGO_ID
 from haystack.utils.highlighting import Highlighter

--- a/haystack/utils/loading.py
+++ b/haystack/utils/loading.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+import six
 from django.utils.module_loading import module_has_submodule
 
 from haystack import constants

--- a/test_haystack/test_indexes.py
+++ b/test_haystack/test_indexes.py
@@ -7,7 +7,7 @@ import time
 from threading import Thread
 
 from django.test import TestCase
-from django.utils.six.moves import queue
+from six.moves import queue
 from test_haystack.core.models import (AFifthMockModel, AThirdMockModel, ManyToManyLeftSideModel,
                                        ManyToManyRightSideModel, MockModel)
 

--- a/test_haystack/test_views.py
+++ b/test_haystack/test_views.py
@@ -8,7 +8,7 @@ from threading import Thread
 from django import forms
 from django.http import HttpRequest, QueryDict
 from django.test import TestCase, override_settings
-from django.utils.six.moves import queue
+from six.moves import queue
 from django.urls import reverse
 from test_haystack.core.models import AnotherMockModel, MockModel
 


### PR DESCRIPTION
Replaced imports from deprecated django modules for django 3.0 compatibility. 

- `force_text` -> `force_str`
- `django.utils.six` -> `six`
